### PR TITLE
Add testing for expected errors (fixes #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,9 @@ Turnt Changelog
 1.2.0 (unreleased)
 ------------------
 
-A new `--args` option lets you override the `args` field that otherwise comes from in-file settings.
+- A new `--args` option lets you override the `args` field that otherwise comes from in-file settings.
+- You can now capture the standard error from a command. In the same way that the `-` pseudo-file indicates the standard output, `2` now indicates the standard error.
+- Tests can now have (non-zero) expected return codes. Use `return_code` in the configuration file or `RETURN` in file comments.
 
 
 1.1.0 (2019-09-12)

--- a/README.md
+++ b/README.md
@@ -49,9 +49,11 @@ These options are available in `turnt.toml`:
 - `output`.
   This is a mapping from extensions to output files to collect from each test.
   For example, use `output.txt = "my_output.txt"` to collect `my_output.txt` after each text extension and save it in `<test-name>.txt`.
-  Use `-` to indicate the command's standard output.
+  Use `-` to indicate the command's standard output and `2` to indicate its standard error.
   The default is like `output.out = "-"`, i.e., capture stdout and save it in `<test-name>.out`.
   You can include this yourself or omit if if you want to ignore the standard output.
+- `return_code`.
+  The expected exit status for the command. By default, 0.
 
 Equivalently, you can embed options in test files themselves:
 
@@ -59,6 +61,7 @@ Equivalently, you can embed options in test files themselves:
 - `OUT: <ext> <filename>` overrides `output` from the configuration.
   You can specify multiple files this way: one line per file.
 - `ARGS: <arguments>`. Add arguments to a configured command (see below).
+- `RETURN: <code>`. The expected exit status.
 
 In commands and filenames, you can use certain patterns that get substituted with details about the tests:
 

--- a/test/bad.err
+++ b/test/bad.err
@@ -1,0 +1,1 @@
+ls: foobarbaz: No such file or directory

--- a/test/bad.t
+++ b/test/bad.t
@@ -1,1 +1,3 @@
 // CMD: ls foobarbaz
+// RETURN: 1
+// OUT: err 2

--- a/turnt.py
+++ b/turnt.py
@@ -17,7 +17,8 @@ __version__ = '1.1.0'
 CONFIG_FILENAME = 'turnt.toml'
 DIFF_CMD = ['diff', '--new-file']
 STDOUT = '-'
-STDERR = '2' 
+STDERR = '2'
+
 
 def load_config(path):
     """Load the configuration for a test at the given path.
@@ -173,7 +174,8 @@ def check_result(name, idx, save, diff, proc, out_files, return_code):
     # If the command has a non-zero exit code, fail.
     if proc.returncode != return_code:
         print('not ok {} - {}'.format(idx, name))
-        print('# exit code: {}, expected: {}'.format(proc.returncode, return_code))
+        print('# exit code: {}, expected: {}'.format(proc.returncode,
+                                                     return_code))
         if proc.stderr:
             sys.stderr.buffer.write(proc.stderr)
             sys.stderr.buffer.flush()
@@ -247,7 +249,7 @@ def run_test(path, idx, save, diff, verbose, dump, args=None):
         return proc.returncode == 0
     else:
         try:
-            def desugar(v): 
+            def desugar(v):
                 if v == STDOUT:
                     return stdout.name
                 elif v == STDERR:
@@ -258,7 +260,8 @@ def run_test(path, idx, save, diff, verbose, dump, args=None):
             # Replace "-" with the standard output file.
             out_files = {k: desugar(v) for (k, v) in out_files.items()}
 
-            return check_result(path, idx, save, diff, proc, out_files, return_code)
+            return check_result(path, idx, save, diff, proc, out_files,
+                                return_code)
         finally:
             os.unlink(stdout.name)
 

--- a/turnt.py
+++ b/turnt.py
@@ -252,16 +252,9 @@ def run_test(path, idx, save, diff, verbose, dump, args=None):
         return proc.returncode == 0
     else:
         try:
-            def desugar(v):
-                if v == STDOUT:
-                    return stdout.name
-                elif v == STDERR:
-                    return stderr.name
-                else:
-                    return v
-
-            # Replace "-" with the standard output file.
-            out_files = {k: desugar(v) for (k, v) in out_files.items()}
+            # Replace shorthands with the standard output/error files.
+            sugar = {STDOUT: stdout.name, STDERR: stderr.name}
+            out_files = {k: sugar.get(v, v) for (k, v) in out_files.items()}
 
             return check_result(path, idx, save, diff, proc, out_files,
                                 return_code)

--- a/turnt.py
+++ b/turnt.py
@@ -174,8 +174,11 @@ def check_result(name, idx, save, diff, proc, out_files, return_code):
     # If the command has a non-zero exit code, fail.
     if proc.returncode != return_code:
         print('not ok {} - {}'.format(idx, name))
-        print('# exit code: {}, expected: {}'.format(proc.returncode,
-                                                     return_code))
+        if return_code:
+            print('# exit code: {}, expected: {}'.format(proc.returncode,
+                                                         return_code))
+        else:
+            print('# exit code: {}'.format(proc.returncode))
         if proc.stderr:
             sys.stderr.buffer.write(proc.stderr)
             sys.stderr.buffer.flush()

--- a/turnt.py
+++ b/turnt.py
@@ -267,6 +267,7 @@ def run_test(path, idx, save, diff, verbose, dump, args=None):
                                 return_code)
         finally:
             os.unlink(stdout.name)
+            os.unlink(stderr.name)
 
 
 @click.command()


### PR DESCRIPTION
Allow users to specify:
(1) Standard error as an output file, using the bash syntactic sugar '2'
(2) Custom expected return codes (default is 0)