### PR TITLE
Configurable diff command

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ These options are available in `turnt.toml`:
   You can include this yourself or omit if if you want to ignore the standard output.
 - `return_code`.
   The expected exit status for the command. By default, 0.
+- `diff`.
+  The command to use for `turnt --diff` output.
 
 Equivalently, you can embed options in test files themselves:
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ These options are available in `turnt.toml`:
   The expected exit status for the command. By default, 0.
 - `diff`.
   The command to use for `turnt --diff` output.
+  The default is `diff --new-file --unified`.
+  Try `git --no-pager diff --no-index` to get colorful output.
 
 Equivalently, you can embed options in test files themselves:
 

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -1,2 +1,3 @@
 command = "echo {base} {args} ; cat {filename}"
 output.out = "-"
+diff = "git --no-pager diff --no-index"

--- a/turnt.py
+++ b/turnt.py
@@ -15,7 +15,7 @@ import contextlib
 __version__ = '1.2.0'
 
 CONFIG_FILENAME = 'turnt.toml'
-DIFF_DEFAULT = 'diff --new-file'
+DIFF_DEFAULT = 'diff --new-file --unified'
 STDOUT = '-'
 STDERR = '2'
 


### PR DESCRIPTION
This makes it possible to specify your own command to use for `turnt --diff` comparisons. It also improves the default a little bit. The README includes a hint about how to get nice colorful diffs by (ab)using git.
