### PR TITLE
Improvements for directory tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ In commands and filenames, you can use certain patterns that get substituted wit
 
 If you need multiple files for a test, you can use a directory instead of a file.
 Turnt will not attempt to read embedded comment options from directories, and outputs will be placed *inside* the test directory instead of adjacent to it.
+Output filenames will be like `out.ext` inside that directory.
+(The `out_base` config option overrides that base filename and is `out` by default.)
 
 
 Command Line

--- a/README.md
+++ b/README.md
@@ -74,9 +74,14 @@ In commands and filenames, you can use certain patterns that get substituted wit
 - `{args}`: Extra arguments specified using `ARGS:` in the test file.
 
 If you need multiple files for a test, you can use a directory instead of a file.
-Turnt will not attempt to read embedded comment options from directories, and outputs will be placed *inside* the test directory instead of adjacent to it.
+Outputs will be placed *inside* the test directory instead of adjacent to it.
 Output filenames will be like `out.ext` inside that directory.
-(The `out_base` config option overrides that base filename and is `out` by default.)
+There are two configurations just for dealing with directory tests:
+
+- `out_base`.
+  The basename for output files in directory tests: by default, `out`.
+- `opts_file`.
+  The filename to read inside of a directory test to parse inline options.
 
 
 Command Line

--- a/turnt.py
+++ b/turnt.py
@@ -162,11 +162,21 @@ def load_options(config, path, args=None):
     `args` can override the arguments for the command, which otherwise
     come from the file itself.
     """
+    # Load the contents for option parsing either from the file itself
+    # or, if the test is a directory, from a file contained therein.
     if os.path.isfile(path):
         with open(path) as f:
             contents = f.read()
     else:
-        contents = ''
+        if 'opts_file' in config:
+            opts_path = os.path.join(path, config['opts_file'])
+            try:
+                with open(opts_path) as f:
+                    contents = f.read()
+            except IOError:
+                contents = ''
+        else:
+            contents = ''
 
     return (
         get_command(config, path, contents, args),

--- a/turnt.py
+++ b/turnt.py
@@ -91,25 +91,28 @@ def format_output_path(name, path):
     )
 
 
-def format_expected_path(ext, path):
+def format_expected_path(ext, path, out_base):
     """Generate the location to use for the *expected* output file for a
     given test `path` and output extension key `ext`.
 
     The resulting path is located "next to" the test file, using its
     basename with a different extension---for example `./foo/bar.t`
     becomes `./foo/bar.ext`. If the test path is a directory, the file is
-    placed *inside* this directory.
+    placed *inside* this directory, and `out_base` is used for the filename
+    instead of the test name (e.g., `./foo/bar.t/out_base.ext`).
     """
-    filename = os.path.basename(path)
-    base, _ = os.path.splitext(filename)
-
-    # When the test is a directory, place results there. Otherwise, when
-    # the test is a file, put results *alongside* the file, in the same
-    # parent directory.
+    # When the test is a directory, place results there and use
+    # `out_base`. Otherwise, when the test is a file, put results
+    # *alongside* the file, in the same parent directory, and use the
+    # test filename to generate the output filename (ignoring
+    # `out_base`).
     if os.path.isdir(path):
         dirname = path
+        base = out_base
     else:
         dirname = os.path.dirname(path)
+        filename = os.path.basename(path)
+        base, _ = os.path.splitext(filename)
 
     return os.path.join(dirname, '{}.{}'.format(base, ext))
 
@@ -120,6 +123,7 @@ def get_out_files(config, path, contents):
     """
     outputs = extract_options(contents, 'out')
 
+    # Get the mapping from extensions to output files.
     if outputs:
         outputs = {k: v for k, v in (o.split() for o in outputs)}
     elif "output" in config:
@@ -128,7 +132,11 @@ def get_out_files(config, path, contents):
         # If no outputs given anywhere, assume standard out.
         outputs = {"out": STDOUT}
 
-    return {format_expected_path(k, path): format_output_path(v, path)
+    # Get the base to use for directory test outputs.
+    out_base = config.get("out_base", "out")
+
+    return {format_expected_path(k, path, out_base):
+            format_output_path(v, path)
             for (k, v) in outputs.items()}
 
 


### PR DESCRIPTION
I'm working on a test suite that wants to use "directory tests," i.e., there are multiple inputs to the compiler. This does two things:

- Outputs from directory tests get a fixed basename, like `my_test/out.s` instead of `my_test/my_test.s`, to reduce redundancy. For example, you can now easily `cp -r` to create a new test based on an old one without needing to muck with the filenames inside.
- Support options in directory tests. Previously, inline options like `CMD:` or `RETURN:` did not work in directory tests because we didn't know which file to look inside. Now a new option, `opts_file`, tells us which file to use.
