### PR TITLE
Kippesp/help fix

### DIFF
--- a/turnt.py
+++ b/turnt.py
@@ -316,7 +316,7 @@ def cli():
               help='Do not suppress stderr from successful commands.')
 @click.option('-a', '--args',
               help='Override arguments for test commands.')
-@click.option('-j', '--parallel',
+@click.option('-j', '--parallel', is_flag=True, default=False,
               help='Run tests in parallel.')
 @click.option('-c', '--config', default='turnt.toml',
               help='Name of the config file. Default: turnt.toml')

--- a/turnt.py
+++ b/turnt.py
@@ -18,6 +18,7 @@ __version__ = '1.6.0'
 DIFF_DEFAULT = 'diff --new-file --unified'
 STDOUT = '-'
 STDERR = '2'
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
 def load_config(path, config_name):
@@ -300,7 +301,11 @@ def run_test(path, config_name, idx, save, diff, verbose, dump, args=None):
             os.unlink(stderr.name)
 
 
-@click.command()
+def cli():
+      pass
+
+
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--save', is_flag=True, default=False,
               help='Save new outputs (overwriting old).')
 @click.option('--diff', is_flag=True, default=False,


### PR DESCRIPTION
Tiny change to address personal frustration that 'click' doesn't default to -h and --help being one in the same.  Fix --parallel to be what it is--a bool.