### PR TITLE
Search for config file in ancestor directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Turnt Changelog
 1.7.0 (in development)
 ----------------------
 
+- Search for `turnt.toml` configuration files in ancestor directories, not just in the same directory as the test.
+
 1.6.0 (2022-06-01)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ These options are available in `turnt.toml`:
 
 - `command`.
   This is a shell command to run for each test input.
+  The working directory for the command is the location of the `turnt.toml` configuration file, if any.
+  If there's no configuration file, then it's the location of the test file itself.
 - `output`.
   This is a mapping from extensions to output files to collect from each test.
   For example, use `output.txt = "my_output.txt"` to collect `my_output.txt` after each text extension and save it in `<test-name>.txt`.
@@ -71,7 +73,7 @@ Equivalently, you can embed options in test files themselves:
 
 In commands and filenames, you can use certain patterns that get substituted with details about the tests:
 
-- `{filename}`: The name of the test file (without the directory part).
+- `{filename}`: The name of the test file, relative to the command working directory.
 - `{base}`: Just the basename of the test file (no extension).
 - `{args}`: Extra arguments specified using `ARGS:` in the test file.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ Or, if you want to work on Turnt, you can install [Flit][], clone this repositor
 Details
 -------
 
+Turnt looks for a configuration file called `turnt.toml` in any of the ancestor directories of your test.
+It can be alongside the test file or in any containing directory.
 These options are available in `turnt.toml`:
 
 - `command`.

--- a/test/subdir/example.out
+++ b/test/subdir/example.out
@@ -1,0 +1,2 @@
+base config
+hello, world!

--- a/test/subdir/example.out
+++ b/test/subdir/example.out
@@ -1,2 +1,3 @@
 base config
+subdir
 hello, world!

--- a/test/subdir/example.out
+++ b/test/subdir/example.out
@@ -1,3 +1,3 @@
 base config
-subdir
+test
 hello, world!

--- a/test/subdir/example.t
+++ b/test/subdir/example.t
@@ -1,0 +1,1 @@
+hello, world!

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -1,0 +1,1 @@
+command = "echo base config ; cat {filename}"

--- a/test/turnt.toml
+++ b/test/turnt.toml
@@ -1,1 +1,3 @@
-command = "echo base config ; cat {filename}"
+# This is the config for the `subdir` test, which tests Turnt's ability to
+# find configurations in ancestor directories.
+command = "echo base config ; basename `pwd` ; cat {filename}"


### PR DESCRIPTION
As discussed in https://github.com/sampsyo/bril/pull/204, this makes it a little easier to share `turnt.toml` files across multiple subdirectories of tests. We now "walk up" from the test's path to look at successive parent directories, stopping at filesystem boundaries.

One last loose end before merging: we need to decide whether the cwd for running the test should be where the _config file_ is (and hence where the command is written) or where the _test file_ is (as it is currently). (Of course, these were one and the same in the previous version.) I am pretty sure it should be relative to the config file, because the whole point is that we want more flexibility about where to put the tests… they can be in many _different_ subdirectories at _different_ levels of nesting, and they want to share _one_ command. So having a relative path in the command only makes sense if it is relative to _that_ configuration.

Directory tests make this a little more complicated.