### PR TITLE
Multiple environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Turnt Changelog
 1.8.0 (in development)
 ----------------------
 
+- Add support for multiple *test environments* that run different commands on the same file. This is especially useful for differential testing, when multiple commands have the same expected output.
 - Flush the output buffer after every line, which makes streaming TAP consumers more useful.
 
 1.7.0 (2022-06-03)

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ These options are useful when working with one specific test file:
 
 These options lets you switch between different test environments:
 
-- `--env` or `-e`: Give the name of a configured [environment](#multiple-environments) to run. Use this multiple times to run multiple environments. By default, Turnt runs all the configured environments for every test.
+- `--env` or `-e`: Give the name of a configured [environment](#multiple-environments) to run. Use this multiple times to run multiple environments. By default, Turnt runs all the configured environments for every test. Use the special name `default` for the top-level, unnamed test environment.
 - `--config` or `-c`: Look for this config filename instead of the default `turnt.toml`.
 
 

--- a/README.md
+++ b/README.md
@@ -153,6 +153,8 @@ If you want a more standard (non-differential) setup, just set the `output` conf
     command = "profile {filename}"
     output.prof = "-"
 
+You can pick which environments you want to run with the `-e` command-line flag (see below).
+
 [dt]: https://en.wikipedia.org/wiki/Differential_testing
 
 
@@ -201,8 +203,9 @@ These options are useful when working with one specific test file:
 - `--print` or `-p`: Instead of checking test results, just run the command and show the output directly. This can be useful (especially in combination with `-v`) when iterating on a test interactively.
 - `--args` or `-a`: Override the `{args}` string in the test command.
 
-This option lets you switch between different test environments:
+These options lets you switch between different test environments:
 
+- `--env` or `-e`: Give the name of a configured [environment](#multiple-environments) to run. Use this multiple times to run multiple environments. By default, Turnt runs all the configured environments for every test.
 - `--config` or `-c`: Look for this config filename instead of the default `turnt.toml`.
 
 

--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ For example:
 Each environment can have the full complement of configuration options described above:
 for example, `command`, `output`, and `return_code`.
 When you run `turnt` on some files, it will run all the environments on all the files.
+There is also a Boolean `default` flag to turn off an environment by default; that way, you can only use it by asking for it with the `-e` flag (see below).
 
 This example is a differential testing setup because both environments share the same (default) snapshot file:
 a test `foo.t` will look for its stdout snapshot in `foo.out`.
@@ -152,8 +153,6 @@ If you want a more standard (non-differential) setup, just set the `output` conf
     [envs.profile]
     command = "profile {filename}"
     output.prof = "-"
-
-You can pick which environments you want to run with the `-e` command-line flag (see below).
 
 [dt]: https://en.wikipedia.org/wiki/Differential_testing
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,44 @@ Put these things into your test file to override the configuration:
 - `RETURN: <code>` overrides the expected exit status.
 
 
+Multiple Environments
+---------------------
+
+Turnt is mostly about running one command on many input files.
+Sometimes, however, you need to run several commands on each file.
+This can be especially useful for *[differential testing][dt]:*
+when you want to check that multiple things behave the same way by checking that they produce the same input when you give them the same input.
+
+You can create multiple environments in your configuration file under the `envs` table.
+The table maps environment *names* to sets of configuration options that are just like the [top-level configuration described above](#configuring).
+For example:
+
+    [envs.baseline]
+    command = "interp -g {filename}"
+
+    [envs.optimized]
+    command = "compile -O3 {filename} ; ./a.out"
+
+Each environment can have the full complement of configuration options described above:
+for example, `command`, `output`, and `return_code`.
+When you run `turnt` on some files, it will run all the environments on all the files.
+
+This example is a differential testing setup because both environments share the same (default) snapshot file:
+a test `foo.t` will look for its stdout snapshot in `foo.out`.
+If the two environments don't match, at least one will fail.
+If you want a more standard (non-differential) setup, just set the `output` configuration differently for the two environments, like this:
+
+    [envs.baseline]
+    command = "interp -g {filename}"
+    output.res = "-"
+
+    [envs.optimized]
+    command = "profile {filename}"
+    output.prof = "-"
+
+[dt]: https://en.wikipedia.org/wiki/Differential_testing
+
+
 Directory Tests
 ---------------
 

--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ a test `foo.t` will look for its stdout snapshot in `foo.out`.
 If the two environments don't match, at least one will fail.
 If you want a more standard (non-differential) setup, just set the `output` configuration differently for the two environments, like this:
 
-    [envs.baseline]
+    [envs.interp]
     command = "interp -g {filename}"
     output.res = "-"
 
-    [envs.optimized]
+    [envs.profile]
     command = "profile {filename}"
     output.prof = "-"
 

--- a/test/multienv/something.out
+++ b/test/multienv/something.out
@@ -1,0 +1,2 @@
+hi
+greetings, earth!

--- a/test/multienv/something.out3
+++ b/test/multienv/something.out3
@@ -1,0 +1,2 @@
+bye
+greetings, earth!

--- a/test/multienv/something.t
+++ b/test/multienv/something.t
@@ -1,0 +1,1 @@
+greetings, earth!

--- a/test/multienv/turnt.toml
+++ b/test/multienv/turnt.toml
@@ -1,9 +1,16 @@
 [envs.one]
 command = "echo env1 >&2 ; echo hi ; cat {filename}"
 
+# This configuration is a "differential testing" pair with the previous one
+# because it shares a single output snapshot file.
 [envs.two]
 command = "echo env2 >&2 ; echo hi ; cat {filename}"
 
+# This one is not because it uses a different file.
 [envs.three]
-command = "echo env2 >&2 ; echo bye ; cat {filename}"
+command = "echo env3 >&2 ; echo bye ; cat {filename}"
 output.out3 = "-"
+
+[envs.four]
+command = "echo env4 >&2 ; exit 42"  # Intentionally fail.
+default = false

--- a/test/multienv/turnt.toml
+++ b/test/multienv/turnt.toml
@@ -1,0 +1,9 @@
+[envs.one]
+command = "echo env1 >&2 ; echo hi ; cat {filename}"
+
+[envs.two]
+command = "echo env2 >&2 ; echo hi ; cat {filename}"
+
+[envs.three]
+command = "echo env2 >&2 ; echo bye ; cat {filename}"
+output.out3 = "-"

--- a/turnt/__main__.py
+++ b/turnt/__main__.py
@@ -22,9 +22,12 @@ CONFIG_NAME = 'turnt.toml'
               help='Run tests in parallel.')
 @click.option('-c', '--config', default=CONFIG_NAME,
               help=f'Name of the config file. Default: {CONFIG_NAME}')
+@click.option('-e', '--env', multiple=True,
+              help='The names of configured environment(s) to run.')
 @click.argument('file', nargs=-1, type=click.Path(exists=True))
 def turnt(file: List[str], save: bool, diff: bool, verbose: bool, dump: bool,
-          args: Optional[str], parallel: bool, config: str) -> None:
+          args: Optional[str], parallel: bool, config: str,
+          env: List[str]) -> None:
     cfg = Config(
         config_name=config,
         save=save,
@@ -32,6 +35,7 @@ def turnt(file: List[str], save: bool, diff: bool, verbose: bool, dump: bool,
         verbose=verbose,
         dump=dump,
         args=args,
+        envs=env,
     )
     success = run_tests(cfg, parallel, file)
     sys.exit(0 if success else 1)

--- a/turnt/config.py
+++ b/turnt/config.py
@@ -210,7 +210,8 @@ def get_envs(config_base: dict, names: List[str]) -> Iterator[TestEnv]:
             yield get_env(env, name)
     else:
         # It's a single-environment configuration.
-        yield get_env(config_base)
+        if not names or 'default' in names:
+            yield get_env(config_base)
 
 
 def extract_options(text: str, key: str) -> List[str]:

--- a/turnt/config.py
+++ b/turnt/config.py
@@ -29,7 +29,7 @@ class Config(NamedTuple):
 class TestEnv(NamedTuple):
     """The configuration values describing how to treat tests.
     """
-    name: str
+    name: Optional[str]
     command: Optional[str]  # Here, a template to be filled in.
     out_files: Dict[str, str]
     return_code: int
@@ -42,7 +42,7 @@ class TestEnv(NamedTuple):
 class Test(NamedTuple):
     """The configuration for running a specific test.
     """
-    env_name: str
+    env_name: Optional[str]
 
     # The test file and its base directory.
     test_path: str
@@ -179,7 +179,7 @@ def load_config(path: str, config_name: str) -> Tuple[dict, str]:
     return {}, os.path.dirname(os.path.abspath(path))
 
 
-def get_env(config_data: dict, name: str) -> TestEnv:
+def get_env(config_data: dict, name: Optional[str] = None) -> TestEnv:
     """Get the settings from a configuration section.
     """
     return TestEnv(
@@ -204,7 +204,7 @@ def get_envs(config_base: dict) -> Iterator[TestEnv]:
             yield get_env(env, name)
     else:
         # It's a single-environment configuration.
-        yield get_env(config_base, 'default')
+        yield get_env(config_base)
 
 
 def extract_options(text: str, key: str) -> List[str]:

--- a/turnt/config.py
+++ b/turnt/config.py
@@ -42,6 +42,8 @@ class TestEnv(NamedTuple):
 class Test(NamedTuple):
     """The configuration for running a specific test.
     """
+    env_name: str
+
     # The test file and its base directory.
     test_path: str
     config_dir: str
@@ -264,6 +266,7 @@ def configure_test(cfg: Config, path: str) -> Iterator[Test]:
             env = env._replace(args=cfg.args)
 
         yield Test(
+            env_name=env.name,
             test_path=path,
             command=format_command(env, config_dir, path),
             config_dir=config_dir,

--- a/turnt/run.py
+++ b/turnt/run.py
@@ -11,6 +11,15 @@ from typing import List, Tuple, Iterator
 from .config import Config, Test, configure_test, map_outputs
 
 
+def tap_line(ok: bool, idx: int, test: Test) -> str:
+    """Format a TAP success/failure line."""
+    return '{} {} - {}'.format(
+        'ok' if ok else 'not ok',
+        idx,
+        test.test_path,
+    )
+
+
 def check_result(cfg: Config, test: Test,
                  proc: subprocess.CompletedProcess,
                  idx: int) -> Tuple[bool, List[str]]:
@@ -20,7 +29,7 @@ def check_result(cfg: Config, test: Test,
     """
     # If the command has a non-zero exit code, fail.
     if proc.returncode != test.return_code:
-        msg = ['not ok {} - {}'.format(idx, test.test_path)]
+        msg = [tap_line(False, idx, test)]
         if test.return_code:
             msg.append('# exit code: {}, expected: {}'.format(
                 proc.returncode, test.return_code,
@@ -62,11 +71,7 @@ def check_result(cfg: Config, test: Test,
             shutil.copy(output_file, saved_file)
 
     # Show TAP success line and annotations.
-    line = '{} {} - {}'.format(
-        'ok' if not differing else 'not ok',
-        idx,
-        test.test_path,
-    )
+    line = tap_line(not differing, idx, test)
     if update:
         line += ' # skip: updated {}'.format(', '.join(test.out_files.keys()))
 

--- a/turnt/run.py
+++ b/turnt/run.py
@@ -13,11 +13,11 @@ from .config import Config, Test, configure_test, map_outputs
 
 def tap_line(ok: bool, idx: int, test: Test) -> str:
     """Format a TAP success/failure line."""
-    return '{} {} - {} {}'.format(
+    return '{} {} - {}{}'.format(
         'ok' if ok else 'not ok',
         idx,
         test.test_path,
-        test.env_name,
+        ' {}'.format(test.env_name) if test.env_name else '',
     )
 
 

--- a/turnt/run.py
+++ b/turnt/run.py
@@ -13,10 +13,11 @@ from .config import Config, Test, configure_test, map_outputs
 
 def tap_line(ok: bool, idx: int, test: Test) -> str:
     """Format a TAP success/failure line."""
-    return '{} {} - {}'.format(
+    return '{} {} - {} {}'.format(
         'ok' if ok else 'not ok',
         idx,
         test.test_path,
+        test.env_name,
     )
 
 

--- a/turnt/run.py
+++ b/turnt/run.py
@@ -7,19 +7,20 @@ import shutil
 import sys
 import contextlib
 from concurrent import futures
-from typing import List, Tuple
+from typing import List, Tuple, Iterator
 from .config import Config, Test, configure_test, map_outputs
 
 
-def check_result(test: Test,
-                 proc: subprocess.CompletedProcess) -> Tuple[bool, List[str]]:
+def check_result(cfg: Config, test: Test,
+                 proc: subprocess.CompletedProcess,
+                 idx: int) -> Tuple[bool, List[str]]:
     """Check the results of a single test and print the outcome.
 
     Return a bool indicating success and a TAP message.
     """
     # If the command has a non-zero exit code, fail.
     if proc.returncode != test.return_code:
-        msg = ['not ok {} - {}'.format(test.idx, test.test_path)]
+        msg = ['not ok {} - {}'.format(idx, test.test_path)]
         if test.return_code:
             msg.append('# exit code: {}, expected: {}'.format(
                 proc.returncode, test.return_code,
@@ -36,7 +37,7 @@ def check_result(test: Test,
     missing = []
     for saved_file, output_file in test.out_files.items():
         # Diff the actual & expected output.
-        if test.cfg.diff:
+        if cfg.diff:
             subprocess.run(test.diff_cmd + [saved_file, output_file])
 
         # Read actual & expected output.
@@ -55,7 +56,7 @@ def check_result(test: Test,
             missing.append(saved_file)
 
     # Save the new output, if requested.
-    update = test.cfg.save and differing
+    update = cfg.save and differing
     if update:
         for saved_file, output_file in test.out_files.items():
             shutil.copy(output_file, saved_file)
@@ -63,7 +64,7 @@ def check_result(test: Test,
     # Show TAP success line and annotations.
     line = '{} {} - {}'.format(
         'ok' if not differing else 'not ok',
-        test.idx,
+        idx,
         test.test_path,
     )
     if update:
@@ -78,15 +79,13 @@ def check_result(test: Test,
     return not differing, [line]
 
 
-def run_test(cfg: Config, path: str, idx: int) -> Tuple[bool, List[str]]:
+def run_test(cfg: Config, test: Test, idx: int) -> Tuple[bool, List[str]]:
     """Run a single test.
 
     Check the output and produce a TAP summary line, unless `dump` is
     enabled, in which case we just print the output. Return a bool
     indicating success and the message.
     """
-    test = configure_test(cfg, path, idx)
-
     # Show the command if we're dumping the output.
     if cfg.dump:
         print('$', test.command, file=sys.stderr)
@@ -121,10 +120,17 @@ def run_test(cfg: Config, path: str, idx: int) -> Tuple[bool, List[str]]:
 
             # Supply outputs and check.
             test = map_outputs(test, stdout.name, stderr.name)
-            return check_result(test, proc)
+            return check_result(cfg, test, proc, idx)
         finally:
             os.unlink(stdout.name)
             os.unlink(stderr.name)
+
+
+def load_tests(cfg: Config, paths: List[str]) -> Iterator[Test]:
+    """Load all the tests to perform for each file.
+    """
+    for path in paths:
+        yield from configure_test(cfg, path)
 
 
 def run_tests(cfg: Config, parallel: bool, test_files: List[str]) -> bool:
@@ -138,7 +144,7 @@ def run_tests(cfg: Config, parallel: bool, test_files: List[str]) -> bool:
         success = True
         with futures.ThreadPoolExecutor() as pool:
             futs = []
-            for idx, path in enumerate(test_files):
+            for idx, path in enumerate(load_tests(cfg, test_files)):
                 futs.append(pool.submit(
                     run_test,
                     cfg, path, idx + 1
@@ -153,7 +159,7 @@ def run_tests(cfg: Config, parallel: bool, test_files: List[str]) -> bool:
     else:
         # Simple sequential loop.
         success = True
-        for idx, path in enumerate(test_files):
+        for idx, path in enumerate(load_tests(cfg, test_files)):
             sc, msg = run_test(cfg, path, idx + 1)
             success &= sc
             for line in msg:


### PR DESCRIPTION
Fixes #8. This makes it possible to configure multiple different treatments for each individual test file. It's sort of like using `-c` to switch between configuration files but a little more convenient. The config syntax looks like this:

```toml
[envs.baseline]
command = "interp -g {filename}"

[envs.optimized]
command = "compile -O3 {filename} ; ./a.out"
```

By default, `turnt` runs all environments. You can pick specific ones by doing `-e baseline` or `-e optimized`. You can also turn off environments by default by adding `default = false`; then, the only way to run them is with `-e`.

The `envs` table is not required; you can still just use a single, top-level environment without a name, like before.