### PR TITLE
Add help alias option "-h"

### DIFF
--- a/turnt/__main__.py
+++ b/turnt/__main__.py
@@ -5,9 +5,10 @@ from .config import Config
 from .run import run_tests
 
 CONFIG_NAME = 'turnt.toml'
+CONTEXT_SETTINGS = dict(help_option_names=['-h', '--help'])
 
 
-@click.command()
+@click.command(context_settings=CONTEXT_SETTINGS)
 @click.option('--save', is_flag=True, default=False,
               help='Save new outputs (overwriting old).')
 @click.option('--diff', is_flag=True, default=False,


### PR DESCRIPTION
I admit up front that this is a somewhat silly PR.  For force-of-habit, -h seems to be my "go to" default.  Since turnt has all the the other options/flags aliased to short names, it seems reasonable.

A quick sampling of other common utilities that don't bind -h and --help,

clang (--help only), ls and du (-h is human readable), dd (long names only)

and others that are aliased,

python, llvm-config, twisted (python), flit, pip