### PR TITLE
Send `--diff` output to stderr (fix #22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Turnt Changelog
 ===============
 
+1.10.0 (in development)
+-----------------------
+
+- The diff output, when `--diff` is enabled, now goes to stderr instead of stdout. This makes it possible to redirect diffs separately from the test results.
+
 1.9.0 (2022-11-02)
 ------------------
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ The most common `turnt` command-line options you'll need while running and updat
 
 - `--save`: Bless the current output from each test as the "correct" output, saving it to the output file that you'll want to check into version control.
 - `--diff`: Show diffs between the actual and expected output for each test.
+  (The diff goes to stderr while the [TAP][] results remain on stdout.)
 
 You also might enjoy:
 

--- a/turnt/__init__.py
+++ b/turnt/__init__.py
@@ -3,4 +3,4 @@ programs.
 """
 from .__main__ import turnt  # noqa
 
-__version__ = '1.9.0'
+__version__ = '1.10.0'

--- a/turnt/run.py
+++ b/turnt/run.py
@@ -48,7 +48,8 @@ def check_result(cfg: Config, test: Test,
     for saved_file, output_file in test.out_files.items():
         # Diff the actual & expected output.
         if cfg.diff:
-            subprocess.run(test.diff_cmd + [saved_file, output_file])
+            subprocess.run(test.diff_cmd + [saved_file, output_file],
+                           stdout=sys.stderr.buffer)
 
         # Read actual & expected output.
         with open(output_file) as f:


### PR DESCRIPTION
This way, you can choose to redirect the diff output separately from the TAP test results. For example:

```
turnt --diff 2> patch.diff
```