### PR TITLE
Customizable test output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ By default, Turnt looks inside test files for overrides (see below).
 This won't work if your test inputs are binary (non-text) files (Turnt will warn you and proceed with no overrides).
 Set `binary = true` to suppress this search for overrides altogether.
 
+### `out_dir`
+
+Optionally put expected test outputs in a different directory.
+By default, this is `.`, i.e., expected output files go "next to" test files.
+Set this to a different directory, relative to the test file, to keep them somewhere else.
+
 
 Per-Test Overrides
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ home-page = "https://github.com/cucapra/turnt"
 description-file = "README.md"
 requires-python = ">=3.6"
 requires = [
-    "click",
+    "click != 8.1.4",
     "tomli >= 1.1.0 ; python_version < \"3.11\"",
 ]
 

--- a/test/out-dir/expected/something.out
+++ b/test/out-dir/expected/something.out
@@ -1,0 +1,2 @@
+something
+hello, world!

--- a/test/out-dir/something.t
+++ b/test/out-dir/something.t
@@ -1,0 +1,1 @@
+hello, world!

--- a/test/out-dir/turnt.toml
+++ b/test/out-dir/turnt.toml
@@ -1,0 +1,2 @@
+command = "echo {base} {args} ; cat {filename}"
+out_dir = "expected"

--- a/turnt/config.py
+++ b/turnt/config.py
@@ -93,11 +93,15 @@ def format_command(env: TestEnv, config_dir: str, path: str) -> str:
 
 
 def format_output_path(name: str, path: str) -> str:
-    """Substitute patterns in configured *actual* output filenames and
-    produce a complete path (relative to `path`, which is the test
-    file).
+    """Get the *actual* output path to be collected from a test run.
+
+    This is the path that the command actually writes to, which we will
+    then collect and compare to the expected output. `name` is the
+    configured name; we substitute patterns in it and treat it relative
+    to `path`, which is the test file. `name` could also indicate the
+    stdout or stderr streams, in which case it is left unchanged.
     """
-    if name == STDOUT or name == STDERR:
+    if name in (STDOUT, STDERR):
         return name
 
     filename = os.path.basename(path)
@@ -112,8 +116,10 @@ def format_output_path(name: str, path: str) -> str:
 
 
 def format_expected_path(ext: str, path: str, out_base: str) -> str:
-    """Generate the location to use for the *expected* output file for a
-    given test `path` and output extension key `ext`.
+    """Get the *expected* output file location for a test environment.
+
+    `path` is the path to the test file itself. `ext` is the output
+    extension key for a given environment.
 
     The resulting path is located "next to" the test file, using its
     basename with a different extension---for example `./foo/bar.t`
@@ -138,12 +144,13 @@ def format_expected_path(ext: str, path: str, out_base: str) -> str:
 
 
 def get_out_files(env: TestEnv, path: str) -> Dict[str, str]:
-    """Get the mapping from saved output files to expected output files
-    for the test.
+    """Get a map from expected to actual output paths for a test.
     """
-    return {format_expected_path(k, path, env.out_base):
-            format_output_path(v, path)
-            for (k, v) in env.out_files.items()}
+    return {
+        format_expected_path(k, path, env.out_base):
+        format_output_path(v, path)
+        for (k, v) in env.out_files.items()
+    }
 
 
 def read_contents(env: TestEnv, path: str) -> str:

--- a/turnt/run.py
+++ b/turnt/run.py
@@ -70,7 +70,10 @@ def check_result(cfg: Config, test: Test,
     update = cfg.save and differing
     if update:
         for saved_file, output_file in test.out_files.items():
-            shutil.copy(output_file, saved_file)
+            parent_dir = os.path.dirname(saved_file)
+            if not os.path.isdir(parent_dir):
+                os.makedirs(parent_dir, exist_ok=True)
+            shutil.copyfile(output_file, saved_file)
 
     # Show TAP success line and annotations.
     line = tap_line(not differing, idx, test)


### PR DESCRIPTION
Normally, expected output files go "next to" test files. A new `out_dir` config option lets you change this, to put expected output files somewhere else (probably a subdirectory). This will be helpful in situations where you need the output to have a specific suffix but that suffix conflicts with other tests or output files. Or if you just want to keep your test directory tidy, with expected outputs separate from the tests themselves.