### PR TITLE
Support "todo" tests (allowed failures)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Turnt Changelog
 ===============
 
+1.12.0 (in development)
+-----------------------
+
+- You can now configure `todo` tests to ignore failures.
+
 1.11.0 (2023-07-08)
 -------------------
 

--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ Optionally put expected test outputs in a different directory.
 By default, this is `.`, i.e., expected output files go "next to" test files.
 Set this to a different directory, relative to the test file, to keep them somewhere else.
 
+### `todo`
+
+Mark a test as an allowed failure.
+You might add a test that exposes a bug that you haven't fixed yet, for example, but you want your CI to stay "green."
+Set `todo = true` to allow the test to fail; Turnt will mark it with `# todo` in the TAP output.
+
 
 Per-Test Overrides
 ------------------
@@ -128,6 +134,7 @@ Put these things into your test file to override the configuration:
 - `OUT: <ext> <filename>` overrides `output` from the configuration.
   You can specify multiple files this way: one line per file.
 - `RETURN: <code>` overrides the expected exit status.
+- `TODO: <true|false>` can mark a test as a "todo" (allowed failure).
 
 
 Multiple Environments

--- a/test/basic/todo.out
+++ b/test/basic/todo.out
@@ -1,0 +1,1 @@
+the wrong output!

--- a/test/basic/todo.t
+++ b/test/basic/todo.t
@@ -1,0 +1,2 @@
+// TODO: true
+something

--- a/turnt/__init__.py
+++ b/turnt/__init__.py
@@ -3,4 +3,4 @@ programs.
 """
 from .__main__ import turnt  # noqa
 
-__version__ = '1.11.0'
+__version__ = '1.12.0'

--- a/turnt/config.py
+++ b/turnt/config.py
@@ -41,6 +41,7 @@ class TestEnv(NamedTuple):
     diff_cmd: List[str]
     args: str
     binary: bool
+    todo: bool
 
 
 class Test(NamedTuple):
@@ -208,6 +209,7 @@ def get_env(config_data: dict, name: Optional[str] = None) -> TestEnv:
         opts_file=config_data.get("opts_file"),
         args='',
         binary=config_data.get('binary', False),
+        todo=config_data.get('todo', False),
     )
 
 
@@ -265,12 +267,14 @@ def override_env(env: TestEnv, contents: str) -> TestEnv:
     outputs = {k: v for k, v in (o.split() for o in output_strs)}
 
     return_code = extract_single_option(contents, 'return')
+    todo = extract_single_option(contents, 'todo')
 
     return env._replace(
         command=extract_single_option(contents, 'cmd') or env.command,
         out_files=outputs or env.out_files,
         args=extract_single_option(contents, 'args') or env.args,
         return_code=int(return_code) if return_code else env.return_code,
+        todo=(todo == 'true') if todo else env.todo,
     )
 
 

--- a/turnt/config.py
+++ b/turnt/config.py
@@ -58,6 +58,7 @@ class Test(NamedTuple):
     out_files: Dict[str, str]
     return_code: int
     diff_cmd: List[str]
+    todo: bool
 
 
 def ancestors(path: str) -> Iterator[str]:
@@ -313,6 +314,7 @@ def configure_test(cfg: Config, path: str) -> Iterator[Test]:
             out_files=get_out_files(env, path),
             return_code=env.return_code,
             diff_cmd=env.diff_cmd,
+            todo=env.todo,
         )
 
 

--- a/turnt/run.py
+++ b/turnt/run.py
@@ -90,7 +90,13 @@ def check_result(cfg: Config, test: Test,
             line += ' # '
         line += 'missing: {}'.format(', '.join(missing))
 
-    return not differing, [line]
+    # Mark "TODO" tests, i.e., allowed failures.
+    success = not differing
+    if test.todo:
+        line += ' # todo'
+        success = True
+
+    return success, [line]
 
 
 def run_test(cfg: Config, test: Test, idx: int) -> Tuple[bool, List[str]]:

--- a/turnt/run.py
+++ b/turnt/run.py
@@ -75,27 +75,29 @@ def check_result(cfg: Config, test: Test,
                 os.makedirs(parent_dir, exist_ok=True)
             shutil.copyfile(output_file, saved_file)
 
-    # Show TAP success line and annotations.
+    # Show TAP success line with directives.
     line = tap_line(not differing, idx, test)
+    directives = []
     if update:
-        line += ' # skip: updated {}'.format(', '.join(test.out_files.keys()))
-
-    diff_exist = [fn for fn in differing if fn not in missing]
-    if diff_exist:
-        line += ' # differing: {}'.format(', '.join(diff_exist))
-    if missing:
-        if diff_exist:
-            line += '; '
-        else:
-            line += ' # '
-        line += 'missing: {}'.format(', '.join(missing))
+        directives.append(
+            'skip: updated {}'.format(', '.join(test.out_files.keys()))
+        )
 
     # Mark "TODO" tests, i.e., allowed failures.
     success = not differing
     if test.todo:
-        line += ' # todo'
         success = True
+        if not update:
+            directives.append('todo')
 
+    diff_exist = [fn for fn in differing if fn not in missing]
+    if diff_exist:
+        directives.append('differing: {}'.format(', '.join(diff_exist)))
+    if missing:
+        directives.append('missing: {}'.format(', '.join(missing)))
+
+    if directives:
+        line += ' # ' + '; '.join(directives)
     return success, [line]
 
 


### PR DESCRIPTION
The TAP spec supports marking a failed test with `# todo` to ignore that it failed. You can now configure tests to allow failure, both in the config file (`todo = true`) and inline (`TODO: true`).