### PR TITLE
Fix test count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Turnt Changelog
 -----------------------
 
 - You can now configure `todo` tests to ignore failures.
+- Fix the reported test count when running multiple environments.
 
 1.11.0 (2023-07-08)
 -------------------

--- a/turnt/run.py
+++ b/turnt/run.py
@@ -158,15 +158,16 @@ def load_tests(cfg: Config, paths: List[str]) -> Iterator[Test]:
 def run_tests(cfg: Config, parallel: bool, test_files: List[str]) -> bool:
     """Run all the tests in an entire suite, possibly in parallel.
     """
+    tests = list(load_tests(cfg, test_files))
     if test_files and not cfg.dump:
-        print('1..{}'.format(len(test_files)))
+        print('1..{}'.format(len(tests)))
 
     if parallel:
         # Parallel test execution.
         success = True
         with futures.ThreadPoolExecutor() as pool:
             futs = []
-            for idx, path in enumerate(load_tests(cfg, test_files)):
+            for idx, path in enumerate(tests):
                 futs.append(pool.submit(
                     run_test,
                     cfg, path, idx + 1
@@ -181,7 +182,7 @@ def run_tests(cfg: Config, parallel: bool, test_files: List[str]) -> bool:
     else:
         # Simple sequential loop.
         success = True
-        for idx, path in enumerate(load_tests(cfg, test_files)):
+        for idx, path in enumerate(tests):
             sc, msg = run_test(cfg, path, idx + 1)
             success &= sc
             for line in msg:


### PR DESCRIPTION
Now that we can run multiple tests (multiple environments) per file, we have to count the tests we extract from the requested file set instead of the length of the file list itself.