### PR TITLE
Replace flit by flit_core in build-system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
-requires = ["flit"]
-build-backend = "flit.buildapi"
+requires = ["flit_core"]
+build-backend = "flit_core.buildapi"
 
 [tool.flit.metadata]
 module = "turnt"


### PR DESCRIPTION
[flit_core](https://pypi.org/project/flit-core/) is the lighter weight PEP 517 build backend. This lets us build the package using a different front-end, such as [`build`](https://pypa-build.readthedocs.io/en/stable/), without pulling in all of flit.