### PR TITLE
Just one Python source file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Install it with [pip][]:
 
     $ pip install --user turnt
 
-Or copy [turnt.py](turnt/__main__.py) directly into your project.
+Or copy [`turnt.py`](turnt.py) directly into your project.
 
 Or, if you want to work on Turnt, you can install [Flit][], clone this repository, and type this to get a "live" installation with a symlink:
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Install
 -------
 
 This is a Python 3 tool.
-Install it with [pip][]:
+Install it with [uv][]:
 
-    $ pip install --user turnt
+    $ uv tool install turnt
 
 Or copy [`turnt.py`](turnt.py) directly into your project.
 
@@ -48,7 +48,7 @@ Or, if you want to work on Turnt, you can install [Flit][], clone this repositor
 
     $ flit install --symlink --user
 
-[pip]: https://pip.pypa.io/
+[uv]: https://docs.astral.sh/uv/
 [flit]: https://flit.readthedocs.io/
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,6 @@ requires = [
 turnt = "turnt:turnt"
 
 [tool.mypy]
-files = ["turnt"]
+files = ["turnt.py"]
 disallow_untyped_calls = true
 disallow_untyped_defs = true

--- a/turnt.py
+++ b/turnt.py
@@ -1,3 +1,6 @@
+"""Turnt is a simple expect-style testing tool for command-line
+programs.
+"""
 import argparse
 import contextlib
 import os
@@ -10,6 +13,7 @@ import tempfile
 from concurrent import futures
 from typing import NamedTuple, List, Tuple, Dict, Iterator, Optional
 
+__version__ = '1.12.0'
 
 if sys.version_info[:2] >= (3, 11):
     import tomllib

--- a/turnt/__init__.py
+++ b/turnt/__init__.py
@@ -1,6 +1,0 @@
-"""Turnt is a simple expect-style testing tool for command-line
-programs.
-"""
-from .__main__ import turnt  # noqa
-
-__version__ = '1.12.0'


### PR DESCRIPTION
As a follow-up to @tekknolagi's #33, just put everything into `turnt.py` for simplicity.