### PR TITLE
Use ruff for Python linting & formatting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,4 +37,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: TrueBrain/actions-flake8@master
+      - name: ruff check
+        uses: astral-sh/ruff-action@v3
+        with:
+          src: turnt.py
+      - name: ruff format
+        uses: astral-sh/ruff-action@v3
+        with:
+          src: turnt.py
+          args: "format --check --diff"


### PR DESCRIPTION
And also do the initial reformatting with `ruff format`. We previously used flake8 for linting and had no formatter.